### PR TITLE
Added activity hooks.

### DIFF
--- a/app/src/main/java/com/berniesanders/connect/BaseActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/BaseActivity.java
@@ -1,7 +1,6 @@
 package com.berniesanders.connect;
 
 import android.os.Bundle;
-import android.os.PersistableBundle;
 import android.support.v7.app.AppCompatActivity;
 
 import com.berniesanders.connect.hook.ActivityHook;
@@ -14,8 +13,8 @@ public class BaseActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState) {
-        super.onCreate(savedInstanceState, persistentState);
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
         for (final ActivityHook hook : mHooks) {
             hook.onCreate(this, savedInstanceState);

--- a/app/src/main/java/com/berniesanders/connect/BaseActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/BaseActivity.java
@@ -1,0 +1,60 @@
+package com.berniesanders.connect;
+
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.berniesanders.connect.hook.ActivityHook;
+
+public class BaseActivity extends AppCompatActivity {
+    private Iterable<ActivityHook> mHooks;
+
+    protected void setHooks(final Iterable<ActivityHook> hooks) {
+        mHooks = hooks;
+    }
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState) {
+        super.onCreate(savedInstanceState, persistentState);
+
+        for (final ActivityHook hook : mHooks) {
+            hook.onCreate(this, savedInstanceState);
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        for (final ActivityHook hook : mHooks) {
+            hook.onDestroy(this);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        for (final ActivityHook hook : mHooks) {
+            hook.onResume(this);
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        for (final ActivityHook hook : mHooks) {
+            hook.onPause(this);
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        for (final ActivityHook hook : mHooks) {
+            hook.onSaveInstanceState(this, outState);
+        }
+    }
+}

--- a/app/src/main/java/com/berniesanders/connect/BaseActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/BaseActivity.java
@@ -5,15 +5,14 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.berniesanders.connect.hook.ActivityHook;
 
-public class BaseActivity extends AppCompatActivity {
+public abstract class BaseActivity extends AppCompatActivity {
     private Iterable<ActivityHook> mHooks;
 
-    protected void setHooks(final Iterable<ActivityHook> hooks) {
-        mHooks = hooks;
-    }
+    protected abstract Iterable<ActivityHook> getHooks();
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
+        mHooks = getHooks();
         super.onCreate(savedInstanceState);
 
         for (final ActivityHook hook : mHooks) {

--- a/app/src/main/java/com/berniesanders/connect/BaseActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/BaseActivity.java
@@ -13,7 +13,7 @@ public class BaseActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         for (final ActivityHook hook : mHooks) {

--- a/app/src/main/java/com/berniesanders/connect/MainActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/MainActivity.java
@@ -8,6 +8,7 @@ import android.widget.FrameLayout;
 
 import com.berniesanders.connect.data.ActionAlert;
 import com.berniesanders.connect.data.ActionAlertAdapter;
+import com.berniesanders.connect.hook.ActivityHook;
 import com.berniesanders.connect.model.ActionAlertsModel;
 
 import java.util.Collections;
@@ -33,10 +34,13 @@ public class MainActivity extends BaseActivity implements ActionAlertAdapter.Cal
     private RecyclerView.LayoutManager layoutManager;
 
     @Override
+    protected Iterable<ActivityHook> getHooks() {
+        return Collections.singletonList(ResumePauseLogger.createHook());
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // inject presenter and other things here,
-        // then get their hooks and set them
-        setHooks(Collections.singletonList(ResumePauseLogger.createHook()));
+        // inject presenter and other things here
         super.onCreate(savedInstanceState);
         ((ConnectApplication)getApplication()).getObjectGraph().inject(this);
         setContentView(R.layout.activity_main);

--- a/app/src/main/java/com/berniesanders/connect/MainActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/MainActivity.java
@@ -1,6 +1,5 @@
 package com.berniesanders.connect;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -11,13 +10,15 @@ import com.berniesanders.connect.data.ActionAlert;
 import com.berniesanders.connect.data.ActionAlertAdapter;
 import com.berniesanders.connect.model.ActionAlertsModel;
 
+import java.util.Collections;
+
 import javax.inject.Inject;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
-public class MainActivity extends AppCompatActivity implements ActionAlertAdapter.Callback {
+public class MainActivity extends BaseActivity implements ActionAlertAdapter.Callback {
 
     @Inject
     ActionAlertsModel actionAlertsModel;
@@ -33,6 +34,9 @@ public class MainActivity extends AppCompatActivity implements ActionAlertAdapte
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // inject presenter and other things here,
+        // then get their hooks and set them
+        setHooks(Collections.singletonList(ResumePauseLogger.createHook()));
         super.onCreate(savedInstanceState);
         ((ConnectApplication)getApplication()).getObjectGraph().inject(this);
         setContentView(R.layout.activity_main);

--- a/app/src/main/java/com/berniesanders/connect/MainActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/MainActivity.java
@@ -33,7 +33,7 @@ public class MainActivity extends BaseActivity implements ActionAlertAdapter.Cal
     private RecyclerView.LayoutManager layoutManager;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         // inject presenter and other things here,
         // then get their hooks and set them
         setHooks(Collections.singletonList(ResumePauseLogger.createHook()));

--- a/app/src/main/java/com/berniesanders/connect/MainActivity.java
+++ b/app/src/main/java/com/berniesanders/connect/MainActivity.java
@@ -33,7 +33,7 @@ public class MainActivity extends BaseActivity implements ActionAlertAdapter.Cal
     private RecyclerView.LayoutManager layoutManager;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         // inject presenter and other things here,
         // then get their hooks and set them
         setHooks(Collections.singletonList(ResumePauseLogger.createHook()));

--- a/app/src/main/java/com/berniesanders/connect/ResumePauseLogger.java
+++ b/app/src/main/java/com/berniesanders/connect/ResumePauseLogger.java
@@ -1,0 +1,15 @@
+package com.berniesanders.connect;
+
+import com.berniesanders.connect.hook.ActivityHook;
+import com.berniesanders.connect.hook.ActivityHookBuilder;
+
+import timber.log.Timber;
+
+public class ResumePauseLogger {
+    public static ActivityHook createHook() {
+        return new ActivityHookBuilder()
+                .onResume(activity -> Timber.v("resume: " + activity.getClass().getSimpleName()))
+                .onPause(activity -> Timber.v("pause: " + activity.getClass().getSimpleName()))
+                .build();
+    }
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityHook.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityHook.java
@@ -1,0 +1,4 @@
+package com.berniesanders.connect.hook;
+
+public interface ActivityHook extends ActivityOnCreate, ActivityOnDestroy, ActivityOnResume, ActivityOnPause, ActivityOnSaveInstanceState {
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityHookBuilder.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityHookBuilder.java
@@ -1,0 +1,77 @@
+package com.berniesanders.connect.hook;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public class ActivityHookBuilder {
+    private ActivityOnCreate mOnCreate;
+    private ActivityOnDestroy mOnDestroy;
+    private ActivityOnResume mOnResume;
+    private ActivityOnPause mOnPause;
+
+    private ActivityOnSaveInstanceState mOnSaveInstanceState;
+
+    public ActivityHookBuilder onPause(final ActivityOnPause onPause) {
+        mOnPause = onPause;
+        return this;
+    }
+
+    public ActivityHookBuilder onResume(final ActivityOnResume onResume) {
+        mOnResume = onResume;
+        return this;
+    }
+
+    public ActivityHookBuilder onDestroy(final ActivityOnDestroy onDestroy) {
+        mOnDestroy = onDestroy;
+        return this;
+    }
+
+    public ActivityHookBuilder onCreate(final ActivityOnCreate onCreate) {
+        mOnCreate = onCreate;
+        return this;
+    }
+
+    public ActivityHookBuilder onSaveInstanceState(final ActivityOnSaveInstanceState onSaveInstanceState) {
+        mOnSaveInstanceState = onSaveInstanceState;
+        return this;
+    }
+
+    public ActivityHook build() {
+        return new ActivityHook() {
+            @Override
+            public void onCreate(final AppCompatActivity activity, final Bundle savedInstanceState) {
+                if (mOnCreate != null) {
+                    mOnCreate.onCreate(activity, savedInstanceState);
+                }
+            }
+
+            @Override
+            public void onDestroy(final AppCompatActivity activity) {
+                if (mOnDestroy != null) {
+                    mOnDestroy.onDestroy(activity);
+                }
+            }
+
+            @Override
+            public void onPause(final AppCompatActivity activity) {
+                if (mOnPause != null) {
+                    mOnPause.onPause(activity);
+                }
+            }
+
+            @Override
+            public void onResume(final AppCompatActivity activity) {
+                if (mOnResume != null) {
+                    mOnResume.onResume(activity);
+                }
+            }
+
+            @Override
+            public void onSaveInstanceState(final AppCompatActivity activity, final Bundle outState) {
+                if (mOnCreate != null) {
+                    mOnSaveInstanceState.onSaveInstanceState(activity, outState);
+                }
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityOnCreate.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityOnCreate.java
@@ -1,0 +1,8 @@
+package com.berniesanders.connect.hook;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public interface ActivityOnCreate {
+    void onCreate(final AppCompatActivity activity, final Bundle savedInstanceState);
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityOnDestroy.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityOnDestroy.java
@@ -1,0 +1,7 @@
+package com.berniesanders.connect.hook;
+
+import android.support.v7.app.AppCompatActivity;
+
+public interface ActivityOnDestroy {
+    void onDestroy(final AppCompatActivity activity);
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityOnPause.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityOnPause.java
@@ -1,0 +1,7 @@
+package com.berniesanders.connect.hook;
+
+import android.support.v7.app.AppCompatActivity;
+
+public interface ActivityOnPause {
+    void onPause(final AppCompatActivity activity);
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityOnResume.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityOnResume.java
@@ -1,0 +1,7 @@
+package com.berniesanders.connect.hook;
+
+import android.support.v7.app.AppCompatActivity;
+
+public interface ActivityOnResume {
+    void onResume(final AppCompatActivity activity);
+}

--- a/app/src/main/java/com/berniesanders/connect/hook/ActivityOnSaveInstanceState.java
+++ b/app/src/main/java/com/berniesanders/connect/hook/ActivityOnSaveInstanceState.java
@@ -1,0 +1,8 @@
+package com.berniesanders.connect.hook;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public interface ActivityOnSaveInstanceState {
+    void onSaveInstanceState(final AppCompatActivity activity, final Bundle outState);
+}


### PR DESCRIPTION
If you want other `AppCompatActivity` methods in `ActivityHook`, then create a similar interface for the method, update the `ActivityHookBuilder`, and override the method in `BaseActivity`. Components that implement their hooks with the builder will not need to change their code when methods are added to `ActivityHook`.

The logger is added as an example. Typically you would inject dependencies to the activity, and then ask the dependencies for their hooks and set them.
